### PR TITLE
Update tab completion install instructions for Bash 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Bash tab-completion is also available and can be enabled by adding the following
 line to your ~/.bashrc file.
 
 ```
-source <(gerrit completion)
+eval "$(gerrit completion)"
 ```
 
 


### PR DESCRIPTION
Not definite, but observed that `source <(gerrit completion)` does not work in Bash 3.2.57 but does in 4.3.33, plus http://lists.gnu.org/archive/html/bug-bash/2006-01/msg00018.html
