### PR TITLE
Allow gerrit topic from dirty index

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1035,7 +1035,6 @@ cli.completion = function() {
 
 cli.topic = function(name, upstream, options) {
   requireInRepo();
-  requireCleanIndex();
 
   if (!upstream) {
     if (!git.branch.hasUpstream()) {
@@ -1048,7 +1047,11 @@ cli.topic = function(name, upstream, options) {
     throw new CliError("Upstream must be a remote branch");
   }
 
-  return gerrit.topic(name, upstream);
+  var result = gerrit.topic(name, upstream);
+  if (result) {
+    logger.info(result);
+  }
+  return result;
 };
 
 cli.squad = {};

--- a/lib/gerrit.js
+++ b/lib/gerrit.js
@@ -527,8 +527,12 @@ gerrit.topic = function(name, upstream) {
   if (!upstream) {
     upstream = git.branch.upstream();
   }
-  git.branch.create(name, "HEAD", true);
-  git.branch.setUpstream("HEAD", upstream);
+  return [
+    git.branch.create(name, "HEAD", true),
+    git.branch.setUpstream("HEAD", upstream),
+  ].filter(function(s) {
+    return !!s;
+  }).join("\n");
 };
 
 gerrit.squad = {};


### PR DESCRIPTION
The new branch is based on the current HEAD, so we don't need
to prevent git checkout when the index is not clean.

It's a convenience for people who forget to make a topic until
they're about to commit.

Note: return value of gerrit.topic is undefined, so I didn't bother forwarding
the return value out of cli.topic.
